### PR TITLE
fix: await chat shutdown and close twitch session

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,15 @@ async def main():
     settings = Settings()
     twitch = await authenticate(settings)
     client = TwichClient(twitch, settings.target_channels)
-    await client.start()
+    try:
+        await client.start()
+    finally:
+        client.stop()
+        await twitch.close()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/src/twitch/twitch_client.py
+++ b/src/twitch/twitch_client.py
@@ -26,6 +26,7 @@ class TwichClient:
     async def start(self) -> None:
         await self.chat
         self.chat.start()
+        await self.chat.join()
 
     def stop(self) -> None:
         self.chat.stop()

--- a/tests/test_twitch_client.py
+++ b/tests/test_twitch_client.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from twitch.twitch_client import TwichClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_client_start_and_stop():
+    twitch = object()
+
+    class DummyChat:
+        def __init__(self, twitch):
+            self.start = Mock()
+            self.join = AsyncMock()
+            self.stop = Mock()
+
+        def register_event(self, *args, **kwargs):
+            pass
+
+        def __await__(self):
+            async def _inner():
+                return self
+
+            return _inner().__await__()
+
+    with patch("twitch.twitch_client.Chat", DummyChat):
+        client = TwichClient(twitch, [])
+        await client.start()
+        client.chat.start.assert_called_once()
+        client.chat.join.assert_called_once()
+        client.stop()
+        client.chat.stop.assert_called_once()


### PR DESCRIPTION
## Summary
- ensure chat startup awaits join and stop cleanup
- close twitch session on shutdown
- add unit test for twitch client lifecycle

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b838df04ec8325af54d7a2e56ca8a4