### PR TITLE
Fix OAuth server shutdown to avoid pending tasks

### DIFF
--- a/src/twitch/twitch_auth.py
+++ b/src/twitch/twitch_auth.py
@@ -57,7 +57,10 @@ async def authenticate(settings: Settings) -> Twitch:
         config = Config(app=app, host="0.0.0.0", port=settings.port, log_level="info")
         server = Server(config)
 
-        auth_service.subscribe_on_complete(lambda: setattr(server, "should_exit", True))
+        async def _request_shutdown() -> None:
+            server.should_exit = True
+
+        auth_service.subscribe_on_complete(_request_shutdown)
 
         logger.info("run uvicorn")
         await server.serve()


### PR DESCRIPTION
## Summary
- allow auth completion hooks to support async callables and execute them in the background response flow
- stop the temporary OAuth server after the confirmation response finishes to prevent pending aiohttp tasks

## Testing
- uv run python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ebcadf3c148325b34c6f3c3ec862f6