### PR TITLE
Add heartbeat file and Docker healthcheck

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -11,5 +11,9 @@ RUN --mount=type=cache,target=/root/.cache/uv uv sync --frozen --no-dev
 
 COPY . .
 
+# Container health is determined by the heartbeat file produced by the app
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD ["bash", "-c", "test -f /app/var/heartbeat && (( $(date +%s) - $(cat /app/var/heartbeat) < 30 ))"]
+
 # Default to running the CLI; additional args can be passed at runtime
 ENTRYPOINT ["uv", "run", "--no-sync", "src/main.py"]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -22,3 +22,5 @@ class Settings(BaseSettings):
     port: int = 8000
 
     storage_path: Path = Path("./var/token.json")
+    heartbeat_path: Path = Path("./var/heartbeat")
+    heartbeat_interval_seconds: float = 10.0

--- a/src/heartbeat.py
+++ b/src/heartbeat.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+
+class Heartbeat:
+    """Persist heartbeat information to a file at a fixed interval."""
+
+    def __init__(self, path: Path, interval: float) -> None:
+        self.path = Path(path)
+        self.interval = float(interval)
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start writing heartbeat signals."""
+
+        if self._task is not None:
+            return
+
+        self._write_heartbeat()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Stop the heartbeat loop."""
+
+        if self._task is None:
+            return
+
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.interval)
+                self._write_heartbeat()
+        except asyncio.CancelledError:
+            raise
+
+    def _write_heartbeat(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(f"{int(time.time())}\n", encoding="utf-8")

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import asyncio
 from loguru import logger
 
 from config.settings import Settings
+from heartbeat import Heartbeat
 from twitch.twitch_auth import authenticate
 from twitch.twitch_client import TwichClient
 
@@ -12,14 +13,20 @@ async def main():
     settings = Settings()
     twitch = await authenticate(settings)
     client = TwichClient(twitch, settings.target_channels)
+    heartbeat = Heartbeat(
+        path=settings.heartbeat_path,
+        interval=settings.heartbeat_interval_seconds,
+    )
 
     try:
+        await heartbeat.start()
         await client.start()
         while True:
             logger.info("live")
             await asyncio.sleep(60)
     finally:
         client.stop()
+        await heartbeat.stop()
         await twitch.close()
 
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,52 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from heartbeat import Heartbeat
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_writes_and_updates_file(tmp_path: Path) -> None:
+    heartbeat_file = tmp_path / "heartbeat"
+    heartbeat = Heartbeat(heartbeat_file, interval=0.01)
+
+    await heartbeat.start()
+    try:
+        await asyncio.sleep(0.02)
+        first_mtime = heartbeat_file.stat().st_mtime
+        first_value = heartbeat_file.read_text(encoding="utf-8").strip()
+
+        await asyncio.sleep(0.02)
+        second_mtime = heartbeat_file.stat().st_mtime
+        second_value = heartbeat_file.read_text(encoding="utf-8").strip()
+    finally:
+        await heartbeat.stop()
+
+    assert heartbeat_file.exists()
+    assert first_value.isdigit()
+    assert second_value.isdigit()
+    assert second_mtime >= first_mtime
+    assert (second_mtime > first_mtime) or (second_value != first_value)
+
+
+@pytest.mark.anyio
+async def test_heartbeat_stop_is_idempotent(tmp_path: Path) -> None:
+    heartbeat_file = tmp_path / "heartbeat"
+    heartbeat = Heartbeat(heartbeat_file, interval=0.01)
+
+    await heartbeat.start()
+    await heartbeat.stop()
+
+    # Multiple stops should not raise
+    await heartbeat.stop()
+
+    assert heartbeat_file.exists()


### PR DESCRIPTION
## Summary
- add a heartbeat writer with configurable path and interval settings
- integrate the heartbeat into the main application loop and expose a Docker healthcheck based on the file
- add automated tests for the heartbeat logic and refresh the Twitch client test expectations

## Testing
- uv run --no-sync pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee09df9bc083258f2c1ff79bc27524